### PR TITLE
fix: middleware 권한 체크 변경 및 server side 로직 변경

### DIFF
--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -4,8 +4,10 @@ import { emailUniqueResponseType } from '@/types/signup.types';
 import { logoutCookie } from '@/utils/auth.util';
 import axiosAPI from '@/utils/axiosAPI';
 import { client } from '@/utils/clientAPI';
+import { createServerAPI } from '@/utils/serverAPI';
 import axios from 'axios';
-import { setCookie } from 'cookies-next';
+import { getCookie, setCookie } from 'cookies-next';
+import { NextRequest, NextResponse } from 'next/server';
 
 export const postSignup = async (userData: User | Admin) => {
   try {
@@ -81,6 +83,22 @@ export const logout = async () => {
     const res = await client.delete('/api/v1/users/logout');
     if (res.data.status === 200) {
       logoutCookie();
+      return res.data.status;
+    } else {
+      console.log(res.data.message);
+    }
+  } catch (error) {
+    console.error('로그아웃 중 오류 발생:', error);
+  }
+};
+
+export const serverLogout = async (req: NextRequest) => {
+  const res = new NextResponse();
+  const accessToken = getCookie('AT', { req, res });
+  const serverAPI = createServerAPI(String(accessToken));
+  try {
+    const res = await serverAPI.delete('/api/v1/users/logout');
+    if (res.data.status === 200) {
       return res.data.status;
     } else {
       console.log(res.data.message);

--- a/src/app/(rootLayout)/role/result/page.tsx
+++ b/src/app/(rootLayout)/role/result/page.tsx
@@ -2,7 +2,7 @@ import RoleSelectForm from '@/components/organisms/roleSelectForm';
 import RoleContainerPage from '@/components/pages/roleContainerPage';
 import RoleWait from '@/components/pages/roleResult/roleWait';
 import { RoleResultEnum } from '@/types/role.types';
-import { serverAPI } from '@/utils/serverAPI';
+import { createServerAPI } from '@/utils/serverAPI';
 import { isTeamSpartaEmail } from '@/utils/utils';
 import { getCookie } from 'cookies-next';
 import { cookies } from 'next/headers';
@@ -14,6 +14,9 @@ const RoleResultPage = async () => {
 
   // 권한 신청 결과 조회 endpoint
   const getRoleApplyResult = async () => {
+    const accessToken = getCookie('AT', { cookies });
+    const serverAPI = createServerAPI(String(accessToken));
+
     try {
       const response = await serverAPI.get('/api/v1/role/result');
       return response.data.data;

--- a/src/app/api/auth/lastConnectRole/route.ts
+++ b/src/app/api/auth/lastConnectRole/route.ts
@@ -1,15 +1,19 @@
 import { LastConnectRoleResponseType } from '@/types/auth.types';
 import { setServerCookieRole } from '@/utils/auth.server.util';
-import { serverAPI } from '@/utils/serverAPI';
-import { NextResponse } from 'next/server';
+import { createServerAPI } from '@/utils/serverAPI';
+import { getCookie } from 'cookies-next';
+import { NextRequest, NextResponse } from 'next/server';
 
-export const GET = async () => {
+export const GET = async (req: NextRequest) => {
+  const res = new NextResponse();
+  const accessToken = getCookie('AT', { req, res });
+  const serverAPI = createServerAPI(String(accessToken));
   try {
     const { data } = await serverAPI.get<LastConnectRoleResponseType>(
       '/api/v1/role/select/last',
     );
 
-    setServerCookieRole(data.data);
+    await setServerCookieRole(data.data);
 
     return new NextResponse('마지막 권한 조회 성공', { status: 200 });
   } catch (error) {

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,9 +1,10 @@
 import { setServerCookieLogin } from '@/utils/auth.server.util';
-import { serverAPI } from '@/utils/serverAPI';
+import { createServerAPI } from '@/utils/serverAPI';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(req: NextRequest) {
   const data = await req.json();
+  const serverAPI = createServerAPI('');
 
   try {
     const response = await serverAPI.post('/api/v1/users/login', {
@@ -12,7 +13,7 @@ export async function POST(req: NextRequest) {
     });
     const accessToken = response.headers.authorization.replace('Bearer ', '');
     if (response?.status === 200) {
-      setServerCookieLogin(accessToken);
+      await setServerCookieLogin(accessToken);
 
       return new NextResponse('로그인 성공', { status: 200 });
     } else {

--- a/src/components/pages/roleResult/roleWait.tsx
+++ b/src/components/pages/roleResult/roleWait.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { logout } from '@/api/authApi';
 import Button from '@/components/atoms/button';
 import { deleteLoginIdCookie } from '@/utils/auth.util';
 import { useRouter } from 'next/navigation';
@@ -7,9 +8,10 @@ import React from 'react';
 
 const RoleWait = () => {
   const router = useRouter();
-  const handleGoToLogin = () => {
-    router.push('/login');
+  const handleGoToLogin = async () => {
+    await logout();
     deleteLoginIdCookie();
+    router.push('/login');
   };
 
   return (

--- a/src/components/pages/signIn.tsx
+++ b/src/components/pages/signIn.tsx
@@ -48,7 +48,6 @@ const SignIn = () => {
 
     try {
       await getLastConnectRole();
-
       router.push('/');
     } catch (error) {
       const roleApplyStatusResponse = await getRoleApplyStatus();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,16 +1,31 @@
 // middleware.ts
-import { getCookie } from 'cookies-next';
+import { serverLogout } from '@/api/authApi';
+import { deleteCookie, getCookie } from 'cookies-next';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next();
   const token = getCookie('AT', { res, req });
+  const role = getCookie('trackRole', { res, req });
+  const { pathname } = req.nextUrl;
 
-  if (token && req.nextUrl.pathname.startsWith('/login')) {
-    return NextResponse.redirect(new URL('/', req.url));
+  // 로그인 정보와 권한이 필요한 페이지
+  // 필요한 페이지 아래와 같이 if문에 추가.
+  if (pathname === '/' || pathname.startsWith('/posts')) {
+    if (!token || !role) {
+      await serverLogout(req);
+      deleteCookie('AT', { res, req });
+      deleteCookie('loginId', { res, req });
+      return NextResponse.redirect(new URL('/login', req.url));
+    }
   }
-  if (!token && !req.nextUrl.pathname.startsWith('/login')) {
-    return NextResponse.redirect(new URL('/login', req.url));
+
+  // 로그인 정보는 필요하지만 권한이 필요없는 페이지
+  // 필요한 페이지 아래와 같이 if문에 추가.
+  if (pathname === '/role/result') {
+    if (!token) {
+      return NextResponse.redirect(new URL('/login', req.url));
+    }
   }
 }
 

--- a/src/utils/auth.server.util.ts
+++ b/src/utils/auth.server.util.ts
@@ -5,7 +5,7 @@ import { deleteCookie, setCookie } from 'cookies-next';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
-export const setServerCookieRole = (data: LastConnectRoleDataType) => {
+export const setServerCookieRole = async (data: LastConnectRoleDataType) => {
   const { trackId, trackRole, trackName, period } = data;
 
   setCookie('trackId', trackId, { cookies });
@@ -14,19 +14,19 @@ export const setServerCookieRole = (data: LastConnectRoleDataType) => {
   setCookie('period', period, { cookies });
 };
 
-export const deleteServerCookieRole = () => {
+export const deleteServerCookieRole = async () => {
   deleteCookie('trackId', { cookies });
   deleteCookie('trackRole', { cookies });
   deleteCookie('trackName', { cookies });
   deleteCookie('period', { cookies });
 };
 
-export const serverLogout = () => {
+export const serverLogout = async () => {
   deleteCookie('AT', { cookies });
-  deleteServerCookieRole();
+  await deleteServerCookieRole();
   redirect('/login');
 };
 
-export const setServerCookieLogin = (accessToken: string) => {
+export const setServerCookieLogin = async (accessToken: string) => {
   setCookie('AT', accessToken, { cookies });
 };

--- a/src/utils/serverAPI.ts
+++ b/src/utils/serverAPI.ts
@@ -1,47 +1,47 @@
 import axios from 'axios';
-import { getCookie } from 'cookies-next';
-import { cookies } from 'next/headers';
 import { serverLogout } from './auth.server.util';
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
 
-export const serverAPI = axios.create({
-  baseURL: BACKEND_URL,
-  withCredentials: true,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
+export const createServerAPI = (accessToken: string) => {
+  const serverAPI = axios.create({
+    baseURL: BACKEND_URL,
+    withCredentials: true,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
 
-serverAPI.interceptors.request.use(
-  async (config) => {
-    const accessToken = getCookie('AT', { cookies });
+  serverAPI.interceptors.request.use(
+    async (config) => {
+      if (accessToken) {
+        config.headers.Authorization = `Bearer ${accessToken}`;
+      } else {
+        console.log('액세스 토큰 오류');
+      }
+      return config;
+    },
 
-    if (accessToken) {
-      config.headers.Authorization = `Bearer ${accessToken}`;
-    } else {
-      console.log('액세스 토큰 오류');
-    }
-    return config;
-  },
+    (error) => Promise.reject(error),
+  );
 
-  (error) => Promise.reject(error),
-);
+  serverAPI.interceptors.response.use(
+    (response) => {
+      console.log('응답 받음:', response.status, response.config.url);
+      return response;
+    },
 
-serverAPI.interceptors.response.use(
-  (response) => {
-    console.log('응답 받음:', response.status, response.config.url);
-    return response;
-  },
+    async (error) => {
+      console.error('API 오류:', error.response?.status, error.response?.data);
+      // 토큰 재발행 로직 추가 예정
 
-  async (error) => {
-    console.error('API 오류:', error.response?.status, error.response?.data);
-    // 토큰 재발행 로직 추가 예정
+      if (error.response?.status === 401) {
+        await serverLogout();
+      }
 
-    if (error.response?.status === 401) {
-      serverLogout();
-    }
+      return Promise.reject(error);
+    },
+  );
 
-    return Promise.reject(error);
-  },
-);
+  return serverAPI;
+};


### PR DESCRIPTION
## 개요
- middleware 수정
- server side logic 변경

## 작업사항
- [x] middleware 수정
 - token이 없고 role이 없으면 login으로 가야될 페이지 설정. 이후에도 지속적으로 token, role 둘다 필요한 페이지는 if문에 추가한다.
 - /role/result는 token만 필요함으로 token이 없을때는 login페이지로 돌려보낸다.
- [x] server side logic 변경
 - server axios Instance에 accessToken 주입 방식으로 변경 server Component와 server action등에서 cookie를 불러오는 방식이 달라 주입방식으로 변경함.

## 관련 이슈
- [x] close #60 
